### PR TITLE
Add Discord Command to Subscribe to Upwork Jobs From RSS Feed

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,6 +4,7 @@ import { Client, Events, GatewayIntentBits, Routes } from "discord";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import ListJobsCommand from "./commands/jobs/list.js";
+import SubscribeJobsCommand from "./commands/jobs/subscribe.js";
 
 yargs(hideBin(process.argv))
   .scriptName("upwork-notifier-bot")
@@ -11,7 +12,7 @@ yargs(hideBin(process.argv))
   .command("start", "Start the Upwork notifier bot", async () => {
     const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-    const commands = [ListJobsCommand];
+    const commands = [ListJobsCommand, SubscribeJobsCommand];
 
     client.once(Events.ClientReady, async (client) => {
       console.log("Client ready!");

--- a/src/commands/jobs/subscribe.test.ts
+++ b/src/commands/jobs/subscribe.test.ts
@@ -1,0 +1,82 @@
+import { CacheType, ChatInputCommandInteraction } from "discord";
+import { jest } from "@jest/globals";
+
+jest.useFakeTimers();
+
+const rssItems = [
+  {
+    title: "First Job",
+    link: "https://www.upwork.com/link-to-first-job",
+    contentSnippet: "Description of the first job",
+    guid: "1",
+  },
+  {
+    title: "Second Job",
+    link: "https://www.upwork.com/link-to-second-job",
+    contentSnippet: "Description of the second job",
+    guid: "2",
+  },
+];
+
+jest.unstable_mockModule("rss-parser", () => ({
+  default: class {
+    async parseURL(url: string) {
+      if (url === "https://www.upwork.com/some-rss") {
+        return { items: rssItems };
+      }
+    }
+  },
+}));
+
+const interaction = {
+  channel: {
+    send: jest.fn(),
+  },
+  options: {
+    getString: (key: string) => {
+      return key === "url" ? "https://www.upwork.com/some-rss" : "";
+    },
+  },
+  reply: jest.fn(),
+};
+
+it("should subscribe jobs from the given RSS feed URL", async () => {
+  const SubscribeJobsCommand = (await import("./subscribe.js")).default;
+
+  await SubscribeJobsCommand.execute(
+    interaction as unknown as ChatInputCommandInteraction<CacheType>,
+  );
+
+  expect(interaction.reply).toHaveBeenCalledTimes(1);
+  expect(interaction.reply).toHaveBeenLastCalledWith(
+    "Subscribed to: <https://www.upwork.com/some-rss>",
+  );
+
+  expect(interaction.channel.send).toHaveBeenCalledTimes(2);
+  expect(interaction.channel.send.mock.calls).toEqual([
+    [
+      "**First Job**\n\n<https://www.upwork.com/link-to-first-job>\n\nDescription of the first job",
+    ],
+    [
+      "**Second Job**\n\n<https://www.upwork.com/link-to-second-job>\n\nDescription of the second job",
+    ],
+  ]);
+
+  await jest.advanceTimersByTimeAsync(60000);
+
+  expect(interaction.channel.send).toHaveBeenCalledTimes(2);
+
+  rssItems.push({
+    title: "Third Job",
+    link: "https://www.upwork.com/link-to-third-job",
+    contentSnippet: "Description of the third job",
+    guid: "3",
+  });
+
+  await jest.advanceTimersByTimeAsync(60000);
+
+  expect(interaction.channel.send).toHaveBeenCalledTimes(3);
+  expect(interaction.channel.send.mock.calls[2]).toEqual([
+    "**Third Job**\n\n<https://www.upwork.com/link-to-third-job>\n\nDescription of the third job",
+  ]);
+});

--- a/src/commands/jobs/subscribe.ts
+++ b/src/commands/jobs/subscribe.ts
@@ -1,0 +1,40 @@
+import {
+  CacheType,
+  ChatInputCommandInteraction,
+  SlashCommandBuilder,
+} from "discord";
+
+import RssParser from "rss-parser";
+
+const rssParser = new RssParser();
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("subscribe-jobs")
+    .setDescription("subscribe to jobs from the given RSS feed URL")
+    .addStringOption((option) =>
+      option
+        .setName("url")
+        .setDescription("The RSS feed URL")
+        .setRequired(true),
+    ),
+  execute: async (interaction: ChatInputCommandInteraction<CacheType>) => {
+    const url = interaction.options.getString("url");
+    await interaction.reply(`Subscribed to: <${url}>`);
+
+    const guids = new Set<string>();
+    const callback = async () => {
+      const feed = await rssParser.parseURL(`${url}`);
+      for (const item of feed.items) {
+        if (guids.has(`${item.guid}`)) continue;
+        guids.add(`${item.guid}`);
+        await interaction.channel?.send(
+          `**${item.title}**\n\n<${item.link}>\n\n${item.contentSnippet}`,
+        );
+      }
+    };
+
+    await callback();
+    setInterval(callback, 60000);
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default as ListJobsCommand } from "./commands/jobs/list.js";
+export { default as SubscribeJobsCommand } from "./commands/jobs/subscribe.js";


### PR DESCRIPTION
This pull request resolves #11 by adding a `subscribe-jobs` command along with its tests. This command will be used to subscribe to new Upwork jobs from the given RSS feed URL.