### PR TITLE
Add Function to Format RSS Feed Items

### DIFF
--- a/src/commands/jobs/list.ts
+++ b/src/commands/jobs/list.ts
@@ -5,6 +5,7 @@ import {
 } from "discord";
 
 import RssParser from "rss-parser";
+import { formatRssFeedItem } from "../../feed.js";
 
 const rssParser = new RssParser();
 
@@ -23,9 +24,7 @@ export default {
     const feed = await rssParser.parseURL(`${url}`);
     await interaction.reply(`Listing ${feed.items.length} jobs:`);
     for (const item of feed.items) {
-      await interaction.channel?.send(
-        `**${item.title}**\n\n<${item.link}>\n\n${item.contentSnippet}`,
-      );
+      await interaction.channel?.send(formatRssFeedItem(item));
     }
   },
 };

--- a/src/commands/jobs/subscribe.ts
+++ b/src/commands/jobs/subscribe.ts
@@ -5,6 +5,7 @@ import {
 } from "discord";
 
 import RssParser from "rss-parser";
+import { formatRssFeedItem } from "../../feed.js";
 
 const rssParser = new RssParser();
 
@@ -28,9 +29,7 @@ export default {
       for (const item of feed.items) {
         if (guids.has(`${item.guid}`)) continue;
         guids.add(`${item.guid}`);
-        await interaction.channel?.send(
-          `**${item.title}**\n\n<${item.link}>\n\n${item.contentSnippet}`,
-        );
+        await interaction.channel?.send(formatRssFeedItem(item));
       }
     };
 

--- a/src/feed.test.ts
+++ b/src/feed.test.ts
@@ -1,0 +1,13 @@
+import { formatRssFeedItem } from "./feed.js";
+
+it("should format a RSS feed item", () => {
+  expect(
+    formatRssFeedItem({
+      title: "Some Job",
+      link: "https://www.upwork.com/link-to-some-job",
+      contentSnippet: "Description of the job",
+    }),
+  ).toBe(
+    "**Some Job**\n\n<https://www.upwork.com/link-to-some-job>\n\nDescription of the job",
+  );
+});

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -1,0 +1,11 @@
+import { Item } from "rss-parser";
+
+/**
+ * Formats the given RSS feed item into a string representation.
+ *
+ * @param item - The RSS feed item to format.
+ * @returns A string representation of the RSS feed item.
+ */
+export function formatRssFeedItem(item: Item): string {
+  return `**${item.title}**\n\n<${item.link}>\n\n${item.contentSnippet}`;
+}


### PR DESCRIPTION
This pull request resolves #13 by adding a `formatRssFeedItem` function along with its tests. This function is used to format a given RSS feed item into a string representation. This change also simplifies the command tests by utilizing the `formatRssFeedItem` function.