### PR TITLE
Handle Edge Cases When Formatting RSS Feed Item

### DIFF
--- a/src/feed.test.ts
+++ b/src/feed.test.ts
@@ -1,6 +1,6 @@
 import { formatRssFeedItem } from "./feed.js";
 
-it("should format a RSS feed item", () => {
+it("should format an RSS feed item", () => {
   expect(
     formatRssFeedItem({
       title: "Some Job",
@@ -10,4 +10,8 @@ it("should format a RSS feed item", () => {
   ).toBe(
     "**Some Job**\n\n<https://www.upwork.com/link-to-some-job>\n\nDescription of the job",
   );
+});
+
+it("should format an RSS feed item with undefined properties", () => {
+  expect(formatRssFeedItem({})).toBe("**Unknown Job**");
 });

--- a/src/feed.ts
+++ b/src/feed.ts
@@ -7,5 +7,8 @@ import { Item } from "rss-parser";
  * @returns A string representation of the RSS feed item.
  */
 export function formatRssFeedItem(item: Item): string {
-  return `**${item.title}**\n\n<${item.link}>\n\n${item.contentSnippet}`;
+  const lines: string[] = [`**${item.title ?? "Unknown Job"}**`];
+  if (item.link !== undefined) lines.push(`<${item.link}>`);
+  if (item.contentSnippet !== undefined) lines.push(item.contentSnippet);
+  return lines.join("\n\n");
 }


### PR DESCRIPTION
This pull request resolves #17 by handling edge cases when formatting an RSS feed item in the `formatRssFeedItem` function.