### PR TITLE
Ask for Token Input if Not Specified in Environment Variable

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,6 +5,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import ListJobsCommand from "./commands/jobs/list.js";
 import SubscribeJobsCommand from "./commands/jobs/subscribe.js";
+import { getToken } from "./token.js";
 
 yargs(hideBin(process.argv))
   .scriptName("upwork-notifier-bot")
@@ -39,7 +40,7 @@ yargs(hideBin(process.argv))
       }
     });
 
-    client.login(process.env["BOT_TOKEN"]);
+    client.login(getToken());
   })
   .demandCommand(1)
   .parse();

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -40,7 +40,7 @@ yargs(hideBin(process.argv))
       }
     });
 
-    client.login(getToken());
+    client.login(await getToken());
   })
   .demandCommand(1)
   .parse();

--- a/src/token.test.ts
+++ b/src/token.test.ts
@@ -1,6 +1,15 @@
+import { Readable } from "node:stream";
 import { getToken } from "./token.js";
 
-it("should retrieve a Discord bot token", () => {
+it("should retrieve a Discord bot token from the environment variables", async () => {
   process.env["BOT_TOKEN"] = "some-token";
-  expect(getToken()).toBe("some-token");
+  await expect(getToken()).resolves.toBe("some-token");
+});
+
+it("should retrieve a Discord bot token from user input", async () => {
+  delete process.env["BOT_TOKEN"];
+  Object.defineProperty(process, "stdin", {
+    value: Readable.from(["some-token\n"]),
+  });
+  await expect(getToken()).resolves.toBe("some-token");
 });

--- a/src/token.test.ts
+++ b/src/token.test.ts
@@ -1,0 +1,6 @@
+import { getToken } from "./token.js";
+
+it("should retrieve a Discord bot token", () => {
+  process.env["BOT_TOKEN"] = "some-token";
+  expect(getToken()).toBe("some-token");
+});

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,0 +1,8 @@
+/**
+ * Retrieves a Discord bot token from the environment variables.
+ *
+ * @returns The Discord bot token.
+ */
+export function getToken(): string {
+  return `${process.env["BOT_TOKEN"]}`;
+}

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,8 +1,17 @@
+import readline from "node:readline/promises";
+
 /**
- * Retrieves a Discord bot token from the environment variables.
+ * Retrieves a Discord bot token from the environment variables or from user input.
  *
- * @returns The Discord bot token.
+ * @returns A promise resolving to the Discord bot token.
  */
-export function getToken(): string {
-  return `${process.env["BOT_TOKEN"]}`;
+export async function getToken(): Promise<string> {
+  const token = process.env["BOT_TOKEN"];
+  if (token !== undefined) return token;
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return await rl.question("Input Discord bot token: ");
 }


### PR DESCRIPTION
This pull request resolves #19 by adding a `getToken` function along with its tests. This function allows retrieving the Discord bot token from the environment variables or from user input if the `BOT_TOKEN` environment variable is not defined.