### PR TITLE
Add Function to Try Sending Message to Channel

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,4 +8,10 @@ export default [
   {
     ignores: [".*", "dist"],
   },
+  {
+    files: ["**/*.test.ts"],
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "catched-error-message": "^0.0.1",
     "discord": "npm:discord.js@^14.15.2",
     "rss-parser": "^3.13.0",
     "yargs": "^17.7.2"

--- a/src/commands/jobs/list.ts
+++ b/src/commands/jobs/list.ts
@@ -6,6 +6,7 @@ import {
 
 import RssParser from "rss-parser";
 import { formatRssFeedItem } from "../../feed.js";
+import { tryToSendMessageToChannel } from "../../message.js";
 
 const rssParser = new RssParser();
 
@@ -24,7 +25,10 @@ export default {
     const feed = await rssParser.parseURL(`${url}`);
     await interaction.reply(`Listing ${feed.items.length} jobs:`);
     for (const item of feed.items) {
-      await interaction.channel?.send(formatRssFeedItem(item));
+      await tryToSendMessageToChannel(
+        formatRssFeedItem(item),
+        interaction.channel,
+      );
     }
   },
 };

--- a/src/commands/jobs/subscribe.ts
+++ b/src/commands/jobs/subscribe.ts
@@ -6,6 +6,7 @@ import {
 
 import RssParser from "rss-parser";
 import { formatRssFeedItem } from "../../feed.js";
+import { tryToSendMessageToChannel } from "../../message.js";
 
 const rssParser = new RssParser();
 
@@ -28,8 +29,11 @@ export default {
       const feed = await rssParser.parseURL(`${url}`);
       for (const item of feed.items) {
         if (guids.has(`${item.guid}`)) continue;
-        guids.add(`${item.guid}`);
-        await interaction.channel?.send(formatRssFeedItem(item));
+        const sent = await tryToSendMessageToChannel(
+          formatRssFeedItem(item),
+          interaction.channel,
+        );
+        if (sent) guids.add(`${item.guid}`);
       }
     };
 

--- a/src/message.test.ts
+++ b/src/message.test.ts
@@ -1,0 +1,38 @@
+import { jest } from "@jest/globals";
+import { tryToSendMessageToChannel } from "./message.js";
+
+const mockedConsoleWarning = jest.spyOn(console, "warn").mockReset();
+
+it.concurrent("should not send a message to an invalid channel", async () => {
+  const prom = tryToSendMessageToChannel("some message", null);
+  await expect(prom).resolves.toBe(false);
+
+  expect(mockedConsoleWarning).toHaveBeenCalledWith(
+    "Could not send a message to an invalid channel",
+  );
+});
+
+it.concurrent("should send a message to a channel", async () => {
+  const channel = { send: jest.fn() };
+
+  const prom = tryToSendMessageToChannel("some message", channel as any);
+  await expect(prom).resolves.toBe(true);
+
+  expect(channel.send).toHaveBeenCalledTimes(1);
+  expect(channel.send).toHaveBeenLastCalledWith("some message");
+});
+
+it.concurrent("should failed to send a message to a channel", async () => {
+  const channel = {
+    send: jest.fn(async () => {
+      throw new Error("some error");
+    }),
+  };
+
+  const prom = tryToSendMessageToChannel("some message", channel as any);
+  await expect(prom).resolves.toBe(false);
+
+  expect(mockedConsoleWarning).toHaveBeenLastCalledWith(
+    "Failed to send a message to the channel: some error",
+  );
+});

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,0 +1,29 @@
+import { getErrorMessage } from "catched-error-message";
+import { TextBasedChannel } from "discord";
+
+/**
+ * Attempts to send a message to a channel.
+ *
+ * @param message - The message to send.
+ * @param channel - The channel to send the message to.
+ * @returns A promise that resolves to a boolean indicating whether the message was sent.
+ */
+export async function tryToSendMessageToChannel(
+  message: string,
+  channel: TextBasedChannel | null,
+): Promise<boolean> {
+  if (channel === null) {
+    console.warn("Could not send a message to an invalid channel");
+    return false;
+  }
+
+  try {
+    await channel.send(message);
+    return true;
+  } catch (err) {
+    console.warn(
+      `Failed to send a message to the channel: ${getErrorMessage(err)}`,
+    );
+    return false;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1802,6 +1802,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"catched-error-message@npm:^0.0.1":
+  version: 0.0.1
+  resolution: "catched-error-message@npm:0.0.1"
+  checksum: 10c0/1f10cd4323a73bec7a57b7495730e5dad9995120b04e85b5f654f7b40dc6a36320d95cc55e49cdf78753158e18790ef725e2ec7309ebced3acd6c9a557ac075b
+  languageName: node
+  linkType: hard
+
 "chalk@npm:^2.4.2":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -4927,6 +4934,7 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@types/yargs": "npm:^17.0.32"
+    catched-error-message: "npm:^0.0.1"
     discord: "npm:discord.js@^14.15.2"
     eslint: "npm:^9.2.0"
     jest: "npm:^29.7.0"


### PR DESCRIPTION
This pull request resolves #29 by introducing the following changes:
- Adds a new `tryToSendMessageToChannel` function along with its tests.
- Ignores the `@typescript-eslint/no-explicit-any` rule in test files.
- Adds `catched-error-message` to the dependencies.