### PR TITLE
Set Module Resolution in TypeScript Configuration

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "exactOptionalPropertyTypes": true,
     "strict": true,
     "module": "node16",
+    "moduleResolution": "node16",
     "declaration": true,
     "outDir": "dist",
     "esModuleInterop": true,


### PR DESCRIPTION
This pull request resolves #33 by setting the `moduleResolution` option in the `tsconfig.json` configuration file to the same value as the `module` option.