### PR TITLE
Store Previously Listed Jobs in Database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ dist/
 node_modules/
 
 *.log
+db.json
 package.tgz

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "catched-error-message": "^0.0.1",
     "discord": "npm:discord.js@^14.15.2",
+    "lowdb": "^7.0.1",
     "pino": "^9.1.0",
     "pino-pretty": "^11.1.0",
     "rss-parser": "^3.13.0",

--- a/src/commands/jobs/subscribe.test.ts
+++ b/src/commands/jobs/subscribe.test.ts
@@ -1,26 +1,16 @@
 import { jest } from "@jest/globals";
 import { CacheType, ChatInputCommandInteraction } from "discord";
-import { formatRssFeedItem } from "../../feed.js";
 
 jest.useFakeTimers();
 
 const rssFeedItems = [
-  {
-    title: "First Job",
-    link: "https://www.upwork.com/link-to-first-job",
-    contentSnippet: "Description of the first job",
-    guid: "1",
-  },
-  {
-    title: "Second Job",
-    link: "https://www.upwork.com/link-to-second-job",
-    contentSnippet: "Description of the second job",
-    guid: "2",
-  },
+  { title: "First Job", guid: "1" },
+  { title: "Second Job", guid: "2" },
+  { title: "Third Job", guid: "3" },
 ];
 
 jest.unstable_mockModule("../../feed.js", () => ({
-  formatRssFeedItem: formatRssFeedItem,
+  formatRssFeedItem: (item: { title: string }) => item.title,
   tryToFetchRssFeedFromUrl: async (url: string) => {
     if (url === "https://www.upwork.com/some-rss") {
       return rssFeedItems;
@@ -52,6 +42,10 @@ const interaction = {
 
 it("should subscribe jobs from the given RSS feed URL", async () => {
   const SubscribeJobsCommand = (await import("./subscribe.js")).default;
+  const store = (await import("../../store.js")).default;
+
+  // Initialize the job with GUID `2` to be already listed.
+  store.update((data) => data.push("2"));
 
   await SubscribeJobsCommand.execute(
     interaction as unknown as ChatInputCommandInteraction<CacheType>,
@@ -62,28 +56,24 @@ it("should subscribe jobs from the given RSS feed URL", async () => {
     "Subscribed to: <https://www.upwork.com/some-rss>",
   );
 
-  expect(interaction.channel.send).toHaveBeenCalledTimes(rssFeedItems.length);
-  expect(interaction.channel.send.mock.calls).toEqual(
-    rssFeedItems.map((item) => [formatRssFeedItem(item)]),
-  );
+  expect(interaction.channel.send.mock.calls).toEqual([
+    ["First Job"],
+    ["Third Job"],
+  ]);
 
   await jest.advanceTimersByTimeAsync(60000);
 
-  expect(interaction.channel.send).toHaveBeenCalledTimes(rssFeedItems.length);
-  expect(interaction.channel.send.mock.calls).toEqual(
-    rssFeedItems.map((item) => [formatRssFeedItem(item)]),
-  );
+  expect(interaction.channel.send.mock.calls).toEqual([
+    ["First Job"],
+    ["Third Job"],
+  ]);
 
-  rssFeedItems.push({
-    title: "Third Job",
-    link: "https://www.upwork.com/link-to-third-job",
-    contentSnippet: "Description of the third job",
-    guid: "3",
-  });
+  rssFeedItems.push({ title: "Fourth Job", guid: "4" });
   await jest.advanceTimersByTimeAsync(60000);
 
-  expect(interaction.channel.send).toHaveBeenCalledTimes(rssFeedItems.length);
-  expect(interaction.channel.send.mock.calls).toEqual(
-    rssFeedItems.map((item) => [formatRssFeedItem(item)]),
-  );
+  expect(interaction.channel.send.mock.calls).toEqual([
+    ["First Job"],
+    ["Third Job"],
+    ["Fourth Job"],
+  ]);
 });

--- a/src/commands/jobs/subscribe.test.ts
+++ b/src/commands/jobs/subscribe.test.ts
@@ -29,6 +29,15 @@ jest.unstable_mockModule("../../feed.js", () => ({
   },
 }));
 
+jest.unstable_mockModule("../../store.js", () => ({
+  default: new (class {
+    data: string[] = [];
+    update(fn: (data: string[]) => void) {
+      fn(this.data);
+    }
+  })(),
+}));
+
 const interaction = {
   channel: {
     send: jest.fn(),

--- a/src/commands/jobs/subscribe.ts
+++ b/src/commands/jobs/subscribe.ts
@@ -6,6 +6,7 @@ import {
 
 import { formatRssFeedItem, tryToFetchRssFeedFromUrl } from "../../feed.js";
 import { tryToSendMessageToChannel } from "../../message.js";
+import store from "../../store.js";
 
 export default {
   data: new SlashCommandBuilder()
@@ -21,16 +22,15 @@ export default {
     const url = interaction.options.getString("url");
     await interaction.reply(`Subscribed to: <${url}>`);
 
-    const guids = new Set<string>();
     const callback = async () => {
       const feed = await tryToFetchRssFeedFromUrl(`${url}`);
       for (const item of feed) {
-        if (guids.has(`${item.guid}`)) continue;
+        if (store.data.includes(`${item.guid}`)) continue;
         const sent = await tryToSendMessageToChannel(
           formatRssFeedItem(item),
           interaction.channel,
         );
-        if (sent) guids.add(`${item.guid}`);
+        if (sent) store.update((data) => data.push(`${item.guid}`));
       }
     };
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,9 @@
+import { Low } from "lowdb";
+import { JSONFile } from "lowdb/node";
+
+const db = new Low<string[]>(new JSONFile("db.json"), []);
+
+await db.read();
+await db.write();
+
+export default db;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3789,6 +3789,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lowdb@npm:^7.0.1":
+  version: 7.0.1
+  resolution: "lowdb@npm:7.0.1"
+  dependencies:
+    steno: "npm:^4.0.2"
+  checksum: 10c0/d61f554d6a507419772b07c91982bb72a0d3976dddef83e1d58fb24ff9049398962ec2c1917b3a863aedb46559081e0cd208d032ff3c43b1d59f41be9f4f4022
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -4857,6 +4866,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"steno@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "steno@npm:4.0.2"
+  checksum: 10c0/fda6bb192bb73ce9453586080aae3fc75506e1c10c9285df49849a016bb9378c6146610f27976708437a6c5492619ec09efb9def6d5397624ae0ad70e57ccaf1
+  languageName: node
+  linkType: hard
+
 "string-length@npm:^4.0.1":
   version: 4.0.2
   resolution: "string-length@npm:4.0.2"
@@ -5228,6 +5244,7 @@ __metadata:
     discord: "npm:discord.js@^14.15.2"
     eslint: "npm:^9.4.0"
     jest: "npm:^29.7.0"
+    lowdb: "npm:^7.0.1"
     pino: "npm:^9.1.0"
     pino-pretty: "npm:^11.1.0"
     pino-test: "npm:^1.0.1"


### PR DESCRIPTION
This pull request resolves #57 by storing the previously listed jobs in a database saved in the `db.json` file. This change also updates the testing for the Subscribe Jobs command accordingly.