### PR TITLE
Separate Function for Handling Job Subscription

### DIFF
--- a/src/commands/jobs/subscribe.ts
+++ b/src/commands/jobs/subscribe.ts
@@ -4,9 +4,7 @@ import {
   SlashCommandBuilder,
 } from "discord";
 
-import { formatRssFeedItem, tryToFetchRssFeedFromUrl } from "../../feed.js";
-import { tryToSendMessageToChannel } from "../../message.js";
-import { isJobPosted, markJobAsPosted } from "../../store/jobs.js";
+import { handleJobSubscription } from "../../schedules/jobs.js";
 
 export default {
   data: new SlashCommandBuilder()
@@ -23,15 +21,7 @@ export default {
     await interaction.reply(`Subscribed to: <${url}>`);
 
     const callback = async () => {
-      const feed = await tryToFetchRssFeedFromUrl(`${url}`);
-      for (const item of feed) {
-        if (isJobPosted(item.guid)) continue;
-        const sent = await tryToSendMessageToChannel(
-          formatRssFeedItem(item),
-          interaction.channel,
-        );
-        if (sent) await markJobAsPosted(item.guid);
-      }
+      await handleJobSubscription(`${url}`, interaction.channel);
     };
 
     await callback();

--- a/src/schedules/jobs.test.ts
+++ b/src/schedules/jobs.test.ts
@@ -1,0 +1,86 @@
+import { jest } from "@jest/globals";
+
+describe("handle a job subscription", () => {
+  const tryToFetchRssFeedFromUrl = jest.fn<any>();
+  const tryToSendMessageToChannel = jest.fn<any>();
+
+  beforeAll(() => {
+    jest.unstable_mockModule("../feed.js", () => ({
+      // Mock the RSS feed item to be formatted with just the item's title.
+      formatRssFeedItem: (item: { title: string }) => item.title,
+
+      tryToFetchRssFeedFromUrl,
+    }));
+
+    jest.unstable_mockModule("../message.js", () => ({
+      tryToSendMessageToChannel,
+    }));
+
+    // Mock the database for storing posted jobs.
+    const postedJobs: string[] = [];
+    jest.unstable_mockModule("../store/jobs.js", () => ({
+      isJobPosted: (jobId: string) => postedJobs.includes(jobId),
+      markJobAsPosted: async (jobId: string) => postedJobs.push(jobId),
+    }));
+  });
+
+  beforeEach(() => {
+    tryToFetchRssFeedFromUrl.mockClear();
+    tryToSendMessageToChannel.mockClear().mockResolvedValue(true);
+  });
+
+  it("should send all job information to the channel", async () => {
+    const { handleJobSubscription } = await import("./jobs.js");
+
+    tryToFetchRssFeedFromUrl.mockResolvedValue([
+      { title: "First Job", guid: "1" },
+      { title: "Second Job", guid: "2" },
+    ]);
+
+    await handleJobSubscription("some URL", "some channel" as any);
+
+    expect(tryToFetchRssFeedFromUrl.mock.calls).toEqual([["some URL"]]);
+
+    // Expect to send all job information to the channel because they all have
+    // not been posted.
+    expect(tryToSendMessageToChannel.mock.calls).toEqual([
+      ["First Job", "some channel"],
+      ["Second Job", "some channel"],
+    ]);
+  });
+
+  it("should not send any job information to the channel", async () => {
+    const { handleJobSubscription } = await import("./jobs.js");
+
+    tryToFetchRssFeedFromUrl.mockResolvedValue([
+      { title: "Second Job", guid: "2" },
+    ]);
+
+    await handleJobSubscription("some URL", "some channel" as any);
+
+    expect(tryToFetchRssFeedFromUrl.mock.calls).toEqual([["some URL"]]);
+
+    // Expect to not send any job information to the channel because they all
+    // have already been posted.
+    expect(tryToSendMessageToChannel.mock.calls).toEqual([]);
+  });
+
+  it("should only send new job information to the channel", async () => {
+    const { handleJobSubscription } = await import("./jobs.js");
+
+    tryToFetchRssFeedFromUrl.mockResolvedValue([
+      { title: "Second Job", guid: "2" },
+      { title: "Third Job", guid: "3" },
+    ]);
+
+    await handleJobSubscription("some URL", "some channel" as any);
+
+    expect(tryToFetchRssFeedFromUrl.mock.calls).toEqual([["some URL"]]);
+
+    // Expect to only send new job information to the channel because some
+    // others have already been posted.
+    expect(tryToSendMessageToChannel.mock.calls).toEqual([
+      ["Third Job", "some channel"],
+    ]);
+  });
+});

--- a/src/schedules/jobs.ts
+++ b/src/schedules/jobs.ts
@@ -1,0 +1,30 @@
+import { TextBasedChannel } from "discord";
+import { formatRssFeedItem, tryToFetchRssFeedFromUrl } from "../feed.js";
+import { tryToSendMessageToChannel } from "../message.js";
+import { isJobPosted, markJobAsPosted } from "../store/jobs.js";
+
+/**
+ * Handles a job subscription.
+ *
+ * This function handles a job subscription by fetching new job information from
+ * the given RSS feed URL and sending the information via messages to the
+ * specified channel.
+ *
+ * @param url - The RSS feed URL.
+ * @param channel - The destination channel.
+ * @returns A promise that resolves to nothing.
+ */
+export async function handleJobSubscription(
+  url: string,
+  channel: TextBasedChannel | null,
+): Promise<void> {
+  const feed = await tryToFetchRssFeedFromUrl(url);
+  for (const item of feed) {
+    if (isJobPosted(item.guid)) continue;
+    const sent = await tryToSendMessageToChannel(
+      formatRssFeedItem(item),
+      channel,
+    );
+    if (sent) await markJobAsPosted(item.guid);
+  }
+}


### PR DESCRIPTION
This pull request resolves #83 by separating the function for handling job subscriptions from the subscribe command into the `handleJobSubscription` function. This change also modifies the tests for the subscribe command accordingly.