### PR TITLE
Reply Command with Failure if Required Options Are Not Provided

### DIFF
--- a/src/commands/jobs/list.test.ts
+++ b/src/commands/jobs/list.test.ts
@@ -1,50 +1,58 @@
 import { jest } from "@jest/globals";
 
-it("should list jobs from the given RSS feed URL", async () => {
+const tryToFetchRssFeedFromUrl = jest.fn<any>();
+const tryToSendMessageToChannel = jest.fn<any>();
+const interactionReply = jest.fn<any>();
+
+beforeAll(() => {
   jest.unstable_mockModule("../../feed.js", () => ({
     // Mock the RSS feed item to be formatted with just the item's title.
     formatRssFeedItem: (item: { title: string }) => item.title,
 
-    // Mock the RSS feed items that will be fetched.
-    tryToFetchRssFeedFromUrl: async (url: string) => {
-      if (url === "https://www.upwork.com/some-rss") {
-        return [
-          { title: "First Job", guid: "1" },
-          { title: "Second Job", guid: "2" },
-        ];
-      }
-      return [];
-    },
+    tryToFetchRssFeedFromUrl,
   }));
 
-  // Mock the function for sending the message.
-  const tryToSendMessageToChannel = jest.fn();
   jest.unstable_mockModule("../../message.js", () => ({
     tryToSendMessageToChannel,
   }));
+});
 
-  // Construct a mocked interaction.
-  const interaction = {
-    channel: {},
-    options: {
-      getString: (key: string) => {
-        if (key === "url") return "https://www.upwork.com/some-rss";
-        return "";
+describe("list jobs from an RSS feed URL", () => {
+  beforeAll(() => {
+    tryToFetchRssFeedFromUrl.mockClear().mockResolvedValue([
+      { title: "First Job", guid: "1" },
+      { title: "Second Job", guid: "2" },
+    ]);
+
+    tryToSendMessageToChannel.mockClear();
+    interactionReply.mockClear();
+  });
+
+  it("should execute the command successfully", async () => {
+    const ListJobsCommand = (await import("./list.js")).default;
+
+    // Execute the command with a mocked interaction.
+    await ListJobsCommand.execute({
+      channel: "some channel",
+      options: {
+        getString: (key: string) => (key === "url" ? "some URL" : ""),
       },
-    },
-    reply: jest.fn(),
-  };
+      reply: interactionReply,
+    } as any);
+  });
 
-  // Execute the command with a mocked interaction.
-  const ListJobsCommand = (await import("./list.js")).default;
-  await ListJobsCommand.execute(interaction as any);
+  it("should fetch jobs from the correct URL", () => {
+    expect(tryToFetchRssFeedFromUrl.mock.calls).toEqual([["some URL"]]);
+  });
 
-  // Expect to reply with the correct message.
-  expect(interaction.reply.mock.calls).toEqual([[`Listing 2 jobs:`]]);
+  it("should reply with the correct message", () => {
+    expect(interactionReply.mock.calls).toEqual([["Listing 2 jobs:"]]);
+  });
 
-  // Expect to send the correct messages to the channel.
-  expect(tryToSendMessageToChannel.mock.calls).toEqual([
-    ["First Job", interaction.channel],
-    ["Second Job", interaction.channel],
-  ]);
+  it("should send the correct messages to the channel", () => {
+    expect(tryToSendMessageToChannel.mock.calls).toEqual([
+      ["First Job", "some channel"],
+      ["Second Job", "some channel"],
+    ]);
+  });
 });

--- a/src/commands/jobs/list.test.ts
+++ b/src/commands/jobs/list.test.ts
@@ -17,6 +17,35 @@ beforeAll(() => {
   }));
 });
 
+describe("list jobs from an empty URL", () => {
+  beforeAll(() => {
+    tryToSendMessageToChannel.mockClear();
+    interactionReply.mockClear();
+  });
+
+  it("should execute the command successfully", async () => {
+    const ListJobsCommand = (await import("./list.js")).default;
+
+    // Execute the command with a mocked interaction.
+    await ListJobsCommand.execute({
+      options: {
+        getString: () => null,
+      },
+      reply: interactionReply,
+    } as any);
+  });
+
+  it("should reply with the correct message", () => {
+    expect(interactionReply.mock.calls).toEqual([
+      ["The `url` option is required to list jobs"],
+    ]);
+  });
+
+  it("should not send any messages to any channels", () => {
+    expect(tryToSendMessageToChannel.mock.calls).toEqual([]);
+  });
+});
+
 describe("list jobs from an RSS feed URL", () => {
   beforeAll(() => {
     tryToFetchRssFeedFromUrl.mockClear().mockResolvedValue([

--- a/src/commands/jobs/list.ts
+++ b/src/commands/jobs/list.ts
@@ -19,7 +19,12 @@ export default {
     ),
   execute: async (interaction: ChatInputCommandInteraction<CacheType>) => {
     const url = interaction.options.getString("url");
-    const feed = await tryToFetchRssFeedFromUrl(`${url}`);
+    if (url === null) {
+      interaction.reply("The `url` option is required to list jobs");
+      return;
+    }
+
+    const feed = await tryToFetchRssFeedFromUrl(url);
     await interaction.reply(`Listing ${feed.length} jobs:`);
     for (const item of feed) {
       await tryToSendMessageToChannel(

--- a/src/commands/jobs/subscribe.test.ts
+++ b/src/commands/jobs/subscribe.test.ts
@@ -9,6 +9,35 @@ beforeAll(() => {
   }));
 });
 
+describe("subscribe jobs from an empty URL", () => {
+  beforeAll(() => {
+    handleJobSubscription.mockClear();
+    interactionReply.mockClear();
+  });
+
+  it("should execute the command successfully", async () => {
+    const SubscribeJobsCommand = (await import("./subscribe.js")).default;
+
+    // Execute the command with a mocked interaction.
+    await SubscribeJobsCommand.execute({
+      options: {
+        getString: () => null,
+      },
+      reply: interactionReply,
+    } as any);
+  });
+
+  it("should reply with the correct message", () => {
+    expect(interactionReply.mock.calls).toEqual([
+      ["The `url` option is required to subscribe to jobs"],
+    ]);
+  });
+
+  it("should not handle the job subscription", () => {
+    expect(handleJobSubscription.mock.calls).toEqual([]);
+  });
+});
+
 describe("subscribe jobs from an RSS feed URL", () => {
   beforeAll(() => {
     jest.useFakeTimers();

--- a/src/commands/jobs/subscribe.ts
+++ b/src/commands/jobs/subscribe.ts
@@ -18,10 +18,15 @@ export default {
     ),
   execute: async (interaction: ChatInputCommandInteraction<CacheType>) => {
     const url = interaction.options.getString("url");
+    if (url === null) {
+      interaction.reply("The `url` option is required to subscribe to jobs");
+      return;
+    }
+
     await interaction.reply(`Subscribed to: <${url}>`);
 
     const callback = async () => {
-      await handleJobSubscription(`${url}`, interaction.channel);
+      await handleJobSubscription(url, interaction.channel);
     };
 
     await callback();


### PR DESCRIPTION
This pull request resolves #85 by modifying the `subscribe-jobs` and `list-jobs` commands to reply to an interaction with a failure message if the required options are not provided. This change also refactors the tests for these commands to ensure the new behavior is properly tested.