### PR TITLE
Reply Command with Failure if Destination Channel Is Not Available

### DIFF
--- a/src/commands/jobs/list.test.ts
+++ b/src/commands/jobs/list.test.ts
@@ -46,6 +46,36 @@ describe("list jobs from an empty URL", () => {
   });
 });
 
+describe("list jobs from an RSS feed URL with an unavailable channel", () => {
+  beforeAll(() => {
+    tryToSendMessageToChannel.mockClear();
+    interactionReply.mockClear();
+  });
+
+  it("should execute the command successfully", async () => {
+    const ListJobsCommand = (await import("./list.js")).default;
+
+    // Execute the command with a mocked interaction.
+    await ListJobsCommand.execute({
+      channel: null,
+      options: {
+        getString: (key: string) => (key === "url" ? "some URL" : ""),
+      },
+      reply: interactionReply,
+    } as any);
+  });
+
+  it("should reply with the correct message", () => {
+    expect(interactionReply.mock.calls).toEqual([
+      ["The destination channel is unavailable for sending the list of jobs."],
+    ]);
+  });
+
+  it("should not send any messages to any channels", () => {
+    expect(tryToSendMessageToChannel.mock.calls).toEqual([]);
+  });
+});
+
 describe("list jobs from an RSS feed URL", () => {
   beforeAll(() => {
     tryToFetchRssFeedFromUrl.mockClear().mockResolvedValue([

--- a/src/commands/jobs/list.ts
+++ b/src/commands/jobs/list.ts
@@ -24,6 +24,13 @@ export default {
       return;
     }
 
+    if (interaction.channel === null) {
+      interaction.reply(
+        "The destination channel is unavailable for sending the list of jobs.",
+      );
+      return;
+    }
+
     const feed = await tryToFetchRssFeedFromUrl(url);
     await interaction.reply(`Listing ${feed.length} jobs:`);
     for (const item of feed) {

--- a/src/commands/jobs/subscribe.test.ts
+++ b/src/commands/jobs/subscribe.test.ts
@@ -38,6 +38,36 @@ describe("subscribe jobs from an empty URL", () => {
   });
 });
 
+describe("subscribe jobs from an RSS feed URL with an unavailable channel", () => {
+  beforeAll(() => {
+    handleJobSubscription.mockClear();
+    interactionReply.mockClear();
+  });
+
+  it("should execute the command successfully", async () => {
+    const SubscribeJobsCommand = (await import("./subscribe.js")).default;
+
+    // Execute the command with a mocked interaction.
+    await SubscribeJobsCommand.execute({
+      channel: null,
+      options: {
+        getString: (key: string) => (key === "url" ? "some URL" : ""),
+      },
+      reply: interactionReply,
+    } as any);
+  });
+
+  it("should reply with the correct message", () => {
+    expect(interactionReply.mock.calls).toEqual([
+      ["The destination channel is unavailable for sending the list of jobs."],
+    ]);
+  });
+
+  it("should not handle the job subscription", () => {
+    expect(handleJobSubscription.mock.calls).toEqual([]);
+  });
+});
+
 describe("subscribe jobs from an RSS feed URL", () => {
   beforeAll(() => {
     jest.useFakeTimers();

--- a/src/commands/jobs/subscribe.ts
+++ b/src/commands/jobs/subscribe.ts
@@ -23,6 +23,13 @@ export default {
       return;
     }
 
+    if (interaction.channel === null) {
+      interaction.reply(
+        "The destination channel is unavailable for sending the list of jobs.",
+      );
+      return;
+    }
+
     await interaction.reply(`Subscribed to: <${url}>`);
 
     const callback = async () => {

--- a/src/commands/jobs/subscribe.ts
+++ b/src/commands/jobs/subscribe.ts
@@ -23,7 +23,8 @@ export default {
       return;
     }
 
-    if (interaction.channel === null) {
+    const channel = interaction.channel;
+    if (channel === null) {
       interaction.reply(
         "The destination channel is unavailable for sending the list of jobs.",
       );
@@ -33,7 +34,7 @@ export default {
     await interaction.reply(`Subscribed to: <${url}>`);
 
     const callback = async () => {
-      await handleJobSubscription(url, interaction.channel);
+      await handleJobSubscription(url, channel);
     };
 
     await callback();

--- a/src/message.test.ts
+++ b/src/message.test.ts
@@ -7,18 +7,6 @@ jest.unstable_mockModule("./logger.js", () => ({
   default: pino(stream),
 }));
 
-it("should not send a message to an invalid channel", async () => {
-  const { tryToSendMessageToChannel } = await import("./message.js");
-
-  const prom = tryToSendMessageToChannel("some message", null);
-  await expect(prom).resolves.toBe(false);
-
-  await pinoTest.once(stream, {
-    level: 40,
-    msg: "Could not send a message to an invalid channel",
-  });
-});
-
 it("should send a message to a channel", async () => {
   const { tryToSendMessageToChannel } = await import("./message.js");
 

--- a/src/message.ts
+++ b/src/message.ts
@@ -11,13 +11,8 @@ import logger from "./logger.js";
  */
 export async function tryToSendMessageToChannel(
   message: string,
-  channel: TextBasedChannel | null,
+  channel: TextBasedChannel,
 ): Promise<boolean> {
-  if (channel === null) {
-    logger.warn("Could not send a message to an invalid channel");
-    return false;
-  }
-
   try {
     await channel.send(message);
     return true;

--- a/src/schedules/jobs.ts
+++ b/src/schedules/jobs.ts
@@ -16,7 +16,7 @@ import { isJobPosted, markJobAsPosted } from "../store/jobs.js";
  */
 export async function handleJobSubscription(
   url: string,
-  channel: TextBasedChannel | null,
+  channel: TextBasedChannel,
 ): Promise<void> {
   const feed = await tryToFetchRssFeedFromUrl(url);
   for (const item of feed) {


### PR DESCRIPTION
This pull request resolves #87 by introducing the following changes:
- Adds a check and returns an error in the `list-jobs` and `subscribe-jobs` commands if the interaction channel is invalid.
- Modifies the `handleJobSubscription` and `tryToSendMessageToChannel` functions from accepting invalid channels.