### PR TITLE
Bump Yarn to Version 4.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,5 @@
     "typescript": "^5.4.5",
     "typescript-eslint": "^8.2.0"
   },
-  "packageManager": "yarn@4.4.0"
+  "packageManager": "yarn@4.4.1"
 }


### PR DESCRIPTION
This pull request simply bumps Yarn to version [4.4.1](https://github.com/yarnpkg/berry/releases/tag/%40yarnpkg%2Fcli%2F4.4.1).