### PR TITLE
Unspecify Yarn Version in Workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Create Package
         run: yarn pack

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Check Format
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Setup Yarn
         uses: threeal/setup-yarn-action@v2.0.0
-        with:
-          version: stable
 
       - name: Test Package
         run: yarn test


### PR DESCRIPTION
This pull request resolves #164 by not specifying the Yarn version when setting up Yarn in GitHub workflows.